### PR TITLE
Removed `f64: Cast<Self>` constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "vecmath"
-version = "0.0.19"
+version = "0.0.20"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["vecmath", "math", "vector", "matrix"]
 description = "A simple and type agnostic library for vector math designed for reexporting"

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -11,9 +11,7 @@ pub trait Float:
     + Div<Self, Output = Self>
     + Rem<Self, Output = Self>
     + Neg<Output = Self>
-    + Trig
-    where f64: Cast<Self>
-{}
+    + Trig {}
 
 impl<T> Float for T where
     T: Copy + Radians + One + Zero + Sqrt
@@ -23,9 +21,7 @@ impl<T> Float for T where
     + Div<T, Output = T>
     + Rem<T, Output = T>
     + Neg<Output = T>
-    + Trig,
-    f64: Cast<T>
-{}
+    + Trig {}
 
 /// Useful constants for radians.
 pub trait Radians {


### PR DESCRIPTION
This does not work as intended, must use explicit `f64: Cast<Self>` in
generic code.